### PR TITLE
:sparkles: feat: 설정 이동 알림창에 취소 버튼 추가

### DIFF
--- a/NewsHabit/Sources/Presenter/Settings/Notification/NotificationViewController.swift
+++ b/NewsHabit/Sources/Presenter/Settings/Notification/NotificationViewController.swift
@@ -48,12 +48,15 @@ extension NotificationViewController: NotificationViewDelegate {
             preferredStyle: .alert
         )
         
-        let action = UIAlertAction(
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let navigateAction = UIAlertAction(
             title: "설정으로 이동",
             style: .default,
             handler: openAppSettings
         )
-        alertController.addAction(action)
+        
+        alertController.addAction(cancelAction)
+        alertController.addAction(navigateAction)
         
         present(alertController, animated: true)
     }


### PR DESCRIPTION
<!--
  :sparkles: [Feature] 제목
  :hammer: [Refactoring] 제목
  :bug: [Fix] 제목
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 알림 권한이 거부된 경우 사용자에게 표시되는 "설정으로 이동" 알림창에 '취소' 버튼을 추가하였습니다. 사용자는 알림 설정 화면으로 바로 이동할 수 있는 옵션과 함께, 필요하지 않다면 알림창을 닫을 수 있습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
|<img width="546" alt="Screenshot 2024-03-14 at 7 40 31 PM" src="https://github.com/Green-Tea-organization/NewsHabit_iOS/assets/116897060/69b06284-b74f-4bcc-9e0c-230fc2dff2eb">|
|-|
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - close #88 