### PR TITLE
:bug: [Fix] 뉴스 데이터 패치 실패 시 에러뷰 겹치는 문제 해결

### DIFF
--- a/NewsHabit/Sources/Presenter/HotNews/HotNewsView.swift
+++ b/NewsHabit/Sources/Presenter/HotNews/HotNewsView.swift
@@ -49,7 +49,7 @@ class HotNewsView: UIView {
     
     private func setupHierarchy() {
         addSubview(tableView)
-        tableView.addSubview(errorView)
+        addSubview(errorView)
     }
     
     private func setupLayout() {
@@ -77,11 +77,13 @@ class HotNewsView: UIView {
                 switch event {
                 case .updateHotNews:
                     self.errorView.isHidden = true
+                    self.tableView.isHidden = false
                     self.tableView.reloadData()
                     self.refreshControl.endRefreshing()
                     self.delegate?.updateDate()
                 case .fetchFailed:
                     self.errorView.isHidden = false
+                    self.tableView.isHidden = true
                     self.refreshControl.endRefreshing()
                 case let .navigateTo(newsLink):
                     self.delegate?.pushViewController(newsLink)

--- a/NewsHabit/Sources/Presenter/HotNews/HotNewsViewModel.swift
+++ b/NewsHabit/Sources/Presenter/HotNews/HotNewsViewModel.swift
@@ -38,7 +38,6 @@ class HotNewsViewModel {
             switch event {
             case .getHotNews:
                 self.fetchNewsData()
-                self.output.send(.updateHotNews)
             case let .tapNewsCell(index):
                 self.output.send(.navigateTo(newsLink: cellViewModels[index].newsLink))
             }

--- a/NewsHabit/Sources/Presenter/Main/TodayNews/TodayNewsView.swift
+++ b/NewsHabit/Sources/Presenter/Main/TodayNews/TodayNewsView.swift
@@ -77,10 +77,12 @@ class TodayNewsView: UIView {
                 switch event {
                 case .updateTodayNews:
                     self.errorView.isHidden = true
+                    self.tableView.isHidden = false
                     self.tableView.reloadData()
                     self.refreshControl.endRefreshing()
                 case .fetchFailed:
                     self.errorView.isHidden = false
+                    self.tableView.isHidden = true
                     self.refreshControl.endRefreshing()
                 case let .navigateTo(newsLink):
                     self.delegate?.pushViewController(newsLink)


### PR DESCRIPTION
<!--
  :sparkles: [Feature] 제목
  :hammer: [Refactoring] 제목
  :bug: [Fix] 제목
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 뉴스 데이터 패치 실패 시, 이전에 로드된 데이터를 보여주는 테이블뷰와 에러 메시지를 표시하는 뷰가 겹쳐 보이는 문제를 해결했습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  |해결 전|해결 후|
  |-|-|
  |![IMG_94C04158E3B3-1](https://github.com/Green-Tea-organization/NewsHabit_iOS/assets/116897060/0dd40347-eb87-44d6-bd55-9ce2c79549ff)|![IMG_F2B0092AB088-1](https://github.com/Green-Tea-organization/NewsHabit_iOS/assets/116897060/22d56a93-57a6-4791-ac90-adc86383338c)|

 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - close #97 